### PR TITLE
Move the hiera packages setup/install into another class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 # Do not forget to download the command line tools for XCode from Apple and store them on a local repository.
 # Caveat: You need an Apple ID to do that!
-# 
+#
 # For Mavericks:
 #  http://adcdownload.apple.com/Developer_Tools/command_line_tools_os_x_mavericks_for_xcode__late_october_2013/command_line_tools_os_x_mavericks_for_xcode__late_october_2013.dmg
 # For Mountain Lion:
@@ -53,6 +53,7 @@ class homebrew (
   $user              = root,
   $group             = brew,
   $update_every      = 'default',
+  $install_packages  = true
 )
 {
   $xcode_cli_install = url_parse($xcode_cli_source, 'filename')
@@ -198,18 +199,8 @@ class homebrew (
     require     => Exec['install-homebrew'],
   }
 
-
-  # Installs brews from hiera
-  $packages = hiera_hash('packages', {})
-  if (!empty($packages))
-  {
-    notice(" Checking packages: ${packages}")
-    $package_defaults = {
-      ensure   => latest,
-      provider => brew,
-      require  => Exec['install-homebrew'],
-    }
-    create_resources(package, $packages, $package_defaults)
+  if $install_packages {
+    include homebrew::packages
   }
 
 }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,0 +1,46 @@
+# == Class: homebrew::packages
+#
+# Install brew packages configured in hiera
+#
+# === Hiera configuration
+#
+#
+# If you use hiera, the puppet class homebrew will search for an entry called "packages".
+# All packages inside that hash will get installed by the homebrew class.
+# Note that packages are merged via the hash method in Hiera. This allows to install common packages on nodes of the same OS, then specific packages on some nodes.
+#
+# === Examples
+#
+# {
+#   "packages": {
+#     "vim": {},
+#     "macvim": {},
+#     "tree": {},
+#     "multitail": {}
+#   }
+# }
+#
+# === Authors
+#
+# Author Name <gildas@breizh.org>
+#
+# === Copyright
+#
+# Copyright 2014, Gildas CHERRUEL.
+#
+
+class homebrew::packages {
+  # Installs brews from hiera
+  $packages = hiera_hash('packages', {})
+  if (!empty($packages))
+  {
+    notice(" Checking packages: ${packages}")
+    $package_defaults = {
+      ensure   => latest,
+      provider => brew,
+      require  => Exec['install-homebrew'],
+    }
+    create_resources(package, $packages, $package_defaults)
+  }
+
+}


### PR DESCRIPTION
We have a similar functionality to install packages based on hiera configs. Unfortunately this conflicts with the module we use.

I think it makes sense to break it into a submodule and make it configurable.
