### PR TITLE
xcodeversion fact always tries to install xcode

### DIFF
--- a/lib/facter/xcodeversion.rb
+++ b/lib/facter/xcodeversion.rb
@@ -1,10 +1,23 @@
 Facter.add(:xcodeversion) do
   confine :operatingsystem => :darwin
   setcode do
-    return "" if ! File.exists?('/usr/bin/xcodebuild')
-    results = %x{ /usr/bin/xcodebuild -version 2>&1 }
-    return "" if ! results =~ /^Xcode\s((?:\d+\.)?(?:\d+\.)?\d+)/
-    $1
+    if File.exists?('/usr/bin/xcodebuild')
+      results = %x{ /usr/bin/xcodebuild -version 2>&1 }
+      if ! results =~ /^Xcode\s((?:\d+\.)?(?:\d+\.)?\d+)/
+        $1
+      end
+    end
   end
-end
+  
+  # At least in Maverics, if you even run xcorebuild it will try to install the tools
+  confine :macosx_productversion_major => "10.9"
+  setcode do
+    if File.exists?('/Applications/Xcode.app') or File.exists?('/Library/Developer/CommandLineTools/')
+      results = %x{ /usr/bin/xcodebuild -version 2>&1 }
+      if results =~ /^Xcode\s((?:\d+\.)?(?:\d+\.)?\d+)/
+        $1
+      end
+    end
+  end
 
+end


### PR DESCRIPTION
Whenever I called "xcodebuild" on Mavericks it would prompt me to install the command line utils.

Also, I think the `return "" if ! File.exists?('/usr/bin/xcodebuild')` causes an error in facter if it doesn't exist (all explicit returns were causing errors for me in facter).

This patch creates a more specific fact for Mavericks (which, since it matches two confines it takes a higher precedence) and just checks for the dirs that are normally created by xcode and xcode cli utils.
