### PR TITLE
The tar extract resets group ownership. Split the creation of /usr/local...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@ class homebrew (
     }
   }
 
-  $homebrew_directories = [ '/usr/local',
+  $homebrew_directories = [
                    '/usr/local/bin',
                    '/usr/local/etc',
                    '/usr/local/include',
@@ -119,6 +119,14 @@ class homebrew (
     require => Group[$group],
   }
 
+  file {'/usr/local':
+    ensure  => directory,
+    owner   => $homebrew::user,
+    group   => $homebrew::group,
+    mode    => '0775',
+    require => Group[$group],
+  }
+
   if (! defined(File['/etc/profile.d']))
   {
     file {'/etc/profile.d':
@@ -140,7 +148,7 @@ class homebrew (
     creates   => '/usr/local/bin/brew',
     logoutput => on_failure,
     timeout   => 0,
-    require   => File[$homebrew_directories],
+    notify    => File[$homebrew_directories]
   }
   if (! $has_compiler)
   {


### PR DESCRIPTION
The tar file provided by homebrew uses a groupname of "wheel" which resets the group ownership of the dirs defined in $homebrew_directories to "wheel" instead of "$homebrew::group".

The only dir you need ahead of time is /usr/local. This change moves the permission settings of the other directories to follow after the tar file is extracted.
