### PR TITLE
Chdir to execute in a directory the user can access

### DIFF
--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -22,7 +22,9 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
     Puppet.debug "command owner is: #{owner}, home: #{environment['HOME']}"
     if super([command(:id), '-u']).to_i.zero?
       Puppet.debug "running command in sudo environment as current user is root"
-      super(cmd, :uid => owner, :failonfail => true, :combine => true, :custom_environment => environment)
+      Dir.chdir(environment['HOME']) do
+        super(cmd, :uid => owner, :failonfail => true, :combine => true, :custom_environment => environment)
+      end
     else
       Puppet.debug "running command with current (non-root) user"
       super(cmd, :failonfail => true, :combine => true, :custom_environment => environment)

--- a/lib/puppet/provider/package/tap.rb
+++ b/lib/puppet/provider/package/tap.rb
@@ -20,7 +20,9 @@ Puppet::Type.type(:package).provide(:tap, :parent => Puppet::Provider::Package) 
     Puppet.debug "command owner is: #{owner}, home: #{environment['HOME']}"
     if super([command(:id), '-u']).to_i.zero?
       Puppet.debug "running command in sudo environment as current user is root"
-      super(cmd, :uid => owner, :failonfail => true, :combine => true, :custom_environment => environment)
+      Dir.chdir(environment['HOME']) do
+        super(cmd, :uid => owner, :failonfail => true, :combine => true, :custom_environment => environment)
+      end
     else
       Puppet.debug "running command with current (non-root) user"
       super(cmd, :failonfail => true, :combine => true, :custom_environment => environment)


### PR DESCRIPTION
Brew needs to be able to retrieve information about the current working directory when it runs.

If we're running puppet as root (e.g. from something like cron), and we're managing homebrew for a non-root user account, it's very likely we'll be running with a current working directory that isn't readable by the homebrew user (e.g. `/var/root`). This means that when we execute a brew command, brew fails with errors about not being able to access the CWD. In effect, the current version of the providers are doing this:

```
# cd /var/root   # (or any dir inaccessible to someuser)
# sudo -u someuser brew list --versions
```

Which results in:

> shell-init: error retrieving current directory: getcwd: cannot access parent directories: Permission denied
chdir: error retrieving current directory: getcwd: cannot access parent directories: Permission denied
chdir: error retrieving current directory: getcwd: cannot access parent directories: Permission denied
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: Permission denied
The current working directory doesn't exist, cannot proceed.

In puppet, these errors look like:

> Could not prefetch package provider 'brew': Could not list packages: Execution of '/usr/local/bin/brew list --versions' returned 1: shell-init: error retrieving current directory: getcwd: cannot access parent directories: Permission denied

In this PR, we change the providers to `cd` to the home dir of the brew user just before the command executes. (The assumption is that a user's own homedir is accessible to them.)