### PR TITLE
Added puppetlabs-stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,6 @@
     }
   ],
   "dependencies": [
-  
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
   ]
 }


### PR DESCRIPTION
This module fails without the puppetlabs-stdlib module. Adding it as a dependency will prevent this.