### PR TITLE
Use execute instead of execpipe

### DIFF
--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -146,19 +146,18 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
   def latest
     Puppet.debug "Querying latest for #{@resource[:name]}"
     begin
-      execpipe([command(:brew), :info, @resource[:name]]) do |process|
-        process.each_line do |line|
-          line.chomp!
-          next if line.empty?
-          next if line !~ /^#{@resource[:name]}:\s(.*)/i
-          Puppet.debug "  Latest versions for #{@resource[:name]}: #{$1}"
-          versions = $1
-          #return 'HEAD' if versions =~ /\bHEAD\b/
-          return $1 if versions =~ /stable (\d+[^\s]*)\s+\(bottled\)/
-          return $1 if versions =~ /stable (\d+.*), HEAD/
-          return $1 if versions =~ /stable (\d+.*)/
-          return $1 if versions =~ /(\d+.*)/
-        end
+      process = execute([command(:brew), :info, @resource[:name]])
+      process.each_line do |line|
+        line.chomp!
+        next if line.empty?
+        next if line !~ /^#{@resource[:name]}:\s(.*)/i
+        Puppet.debug "  Latest versions for #{@resource[:name]}: #{$1}"
+        versions = $1
+        #return 'HEAD' if versions =~ /\bHEAD\b/
+        return $1 if versions =~ /stable (\d+[^\s]*)\s+\(bottled\)/
+        return $1 if versions =~ /stable (\d+.*), HEAD/
+        return $1 if versions =~ /stable (\d+.*)/
+        return $1 if versions =~ /(\d+.*)/
       end
       nil
     rescue Puppet::ExecutionFailure

--- a/lib/puppet/provider/package/tap.rb
+++ b/lib/puppet/provider/package/tap.rb
@@ -67,13 +67,12 @@ Puppet::Type.type(:package).provide(:tap, :parent => Puppet::Provider::Package) 
     Puppet.debug "Listing currently tapped repositories"
     taps = []
     begin
-      execpipe([command(:brew), :tap]) do |process|
-        process.each_line do |line|
-          line.chomp!
-          next if line.empty?
-          Puppet.debug "  Repository #{line} is currently tapped."
-          taps << new({ :name => line, :ensure => 'present', :provider => 'tap' })
-        end
+      process = execute([command(:brew), :tap])
+      process.each_line do |line|
+        line.chomp!
+        next if line.empty?
+        Puppet.debug "  Repository #{line} is currently tapped."
+        taps << new({ :name => line, :ensure => 'present', :provider => 'tap' })
       end
       taps
     rescue Puppet::ExecutionFailure


### PR DESCRIPTION
Current version of brew does not allow 'brew tap' to be run as root.  Figured I would fix the execpipe() in homebrew.rb as well.

This fixes the following error:

Error: Instances failed: #<IO:0x007fc02df13d68>
Error: Could not prefetch package provider 'tap': undefined method `each' for nil:NilClass
