### PR TITLE
Make module behaviour consistent despite value of stringify_facts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,7 @@ class homebrew (
   if ($xcode_cli_source) {
     $xcode_cli_install = url_parse($xcode_cli_source, 'filename')
 
-    if ($::has_compiler != true or ($xcode_cli_version and $::xcodeversion != $xcode_cli_version))
+    if (! str2bool("$::has_compiler") or ($xcode_cli_version and $::xcodeversion != $xcode_cli_version))
     {
       package {$xcode_cli_install:
         ensure   => present,
@@ -182,7 +182,7 @@ class homebrew (
     require => File['/etc/profile.d'],
   }
 
-  if ($::has_compiler != true and $xcode_cli_source)
+  if (! str2bool("$::has_compiler") and $xcode_cli_source)
   {
     Package[$xcode_cli_install] -> Exec['install-homebrew']
   }


### PR DESCRIPTION
Right now, it's possible that the comparison on the `$::has_compiler` fact may not return the intended result depending on the value of [`stringify_facts`](https://docs.puppet.com/puppet/3.8/configuration.html#stringifyfacts) in `puppet.conf`.

In Puppet 3, this value defaults to `true` which means all Facts when looked up are passed through `#to_s`.  This means that if the fact has the value of `false`, it will be considered true when evaluated.  

To illustrate this, consider the following:

```
drew@server# facter -p selinux
false

drew@server# cat /tmp/selinux.pp
if $::selinux {
  notify {"SELinux is enabled":}
} else {
  notify {"SELinux is disabled":}
}

drew@server# grep stringify_facts /etc/puppet/puppet.conf
stringify_facts = true

drew@server# puppet apply /tmp/selinux.pp
<...snip...>
Notice: SELinux is enabled
<...snip...>
```

If I remember correctly, even blank strings returned from Facter will evaluate to true when flattened.

Since there's already a dependancy on `puppetlabs-stdlib`, we can use `str2bool()` to make this backwards compatible.  It's a recommended method from Puppet themselves during the upgrade process ([source](https://docs.puppet.com/puppet/4.9/upgrade_major_pre.html#stop-stringifying-facts-and-check-for-breakage))